### PR TITLE
Update Round-Robin as per #48 in packet-scheduling

### DIFF
--- a/lib/alg.ml
+++ b/lib/alg.ml
@@ -112,7 +112,7 @@ let rrobin n = (
       let skipped = who_skip (pkt_to_int pkt) (int_of_float turn) in
       let f s i = 
         let r_i = "r_" ^ (string_of_int i) in
-        State.rebind r_i (State.lookup r_i s +. (2.0 *. (float_of_int n))) s
+        State.rebind r_i (State.lookup r_i s +. (float_of_int n)) s
       in
       List.fold_left f s' skipped
 

--- a/lib/alg.ml
+++ b/lib/alg.ml
@@ -107,7 +107,7 @@ let rrobin n = (
 
     let z_out s pkt = 
       let turn = State.lookup "turn" s in
-      let turn' = ((int_of_float turn) + 1) mod n |> float_of_int in
+      let turn' = ((pkt_to_int pkt) + 1) mod n |> float_of_int in 
       let s' = State.rebind "turn" turn' s in
       let skipped = who_skip (pkt_to_int pkt) (int_of_float turn) in
       let f s i = 

--- a/lib/alg.ml
+++ b/lib/alg.ml
@@ -36,7 +36,7 @@ module FCFS_Ternary : Alg_t = struct
       s = State.create 1;
       q = Pieotree.create topology;
       z_in = scheduling_transaction;
-      z_out = fun x -> fun _ -> x;
+      z_out = fun s _ -> s;
     }
 
   let simulate sim_length pkts =
@@ -65,7 +65,7 @@ module Strict_Ternary : Alg_t = struct
       s = State.create 1;
       q = Pieotree.create topology;
       z_in = scheduling_transaction;
-      z_out = fun x -> fun _ -> x;
+      z_out = fun s _ -> s;
     }
 
   let simulate sim_length pkts =
@@ -184,7 +184,7 @@ module WFQ_Ternary : Alg_t = struct
       s = init_state; 
       q = Pieotree.create topology; 
       z_in = scheduling_transaction; 
-      z_out = fun x -> fun _ -> x;
+      z_out = fun s _ -> s;
     }
 
   let simulate sim_length pkts =
@@ -257,7 +257,7 @@ module HPFQ_Binary : Alg_t = struct
         |> State.rebind "C_weight" 0.2;
       q = Pieotree.create topology;
       z_in = scheduling_transaction;
-      z_out = fun x -> fun _ -> x;
+      z_out = fun s _ -> s;
     }
 
   let simulate sim_length pkts =
@@ -324,7 +324,7 @@ module TwoPol_Ternary : Alg_t = struct
         |> State.rebind "CDE_weight" 0.8;
       q = Pieotree.create topology;
       z_in = scheduling_transaction;
-      z_out = fun x -> fun _ -> x;
+      z_out = fun s _ -> s;
     }
 
   let simulate sim_length pkts =
@@ -452,7 +452,7 @@ module ThreePol_Ternary : Alg_t = struct
         |> State.rebind "G_weight" 0.5;
       q = Pieotree.create topology;
       z_in = scheduling_transaction;
-      z_out = fun x -> fun _ -> x;
+      z_out = fun s _ -> s;
     }
 
   let simulate sim_length pkts =
@@ -536,7 +536,7 @@ module Extension_Flat : Alg_t = struct
       s = State.create 1;
       q = Pieotree.create topology;
       z_in = scheduling_transaction;
-      z_out = fun x -> fun _ -> x;
+      z_out = fun s _ -> s;
     }
 
   let simulate sim_length pkts =
@@ -595,7 +595,7 @@ module Shifted_FCFS_Ternary : Alg_t = struct
       s = State.create 1;
       q = Pieotree.create topology;
       z_in = scheduling_transaction;
-      z_out = fun x -> fun _ -> x;
+      z_out = fun s _ -> s;
     }
 
   let simulate sim_length pkts =
@@ -648,7 +648,7 @@ module Rate_Limit_WFQ_Quaternary : Alg_t = struct
       s = init_state; 
       q = Pieotree.create topology; 
       z_in = scheduling_transaction;
-      z_out = fun x -> fun _ -> x;
+      z_out = fun s _ -> s;
     }
 
   let simulate sim_length pkts =

--- a/lib/alg.ml
+++ b/lib/alg.ml
@@ -35,7 +35,8 @@ module FCFS_Ternary : Alg_t = struct
     {
       s = State.create 1;
       q = Pieotree.create topology;
-      z = scheduling_transaction;
+      z_in = scheduling_transaction;
+      z_out = fun x -> fun _ -> x;
     }
 
   let simulate sim_length pkts =
@@ -63,51 +64,80 @@ module Strict_Ternary : Alg_t = struct
     {
       s = State.create 1;
       q = Pieotree.create topology;
-      z = scheduling_transaction;
+      z_in = scheduling_transaction;
+      z_out = fun x -> fun _ -> x;
     }
 
   let simulate sim_length pkts =
     Control.simulate sim_length 0.001 poprate pkts control
 end
 
-module RRobin_Ternary : Alg_t = struct
-  let scheduling_transaction s pkt =
-    let time = Packet.time pkt in
-    let flow = Packet.find_flow pkt in
-    let var_last_finish = Printf.sprintf "%s_last_finish" (Flow.to_string flow) in
-    (* We will use this variable to read/write to state. *)
-    let rank_for_root =
-      if State.isdefined var_last_finish s then
-        max (Time.to_float time) (State.lookup var_last_finish s)
-      else Time.to_float time
-    in
-    let s' =
-      State.rebind var_last_finish (rank_for_root +. (100.0 /. 0.33)) s
-    in
-    let rank_for_root = Rank.create rank_for_root time in
-    let int_for_root =
-      (* Put flow A into leaf 0, flow B into leaf 1, and flow C into leaf 2. *)
-      match flow with
+let rrobin n = (
+  module struct
+    (* n-flow Round-Robin *)
+    let _ = assert (n <= 7 && n > 0)
+
+    let who_skip pop turn = 
+      let rec who_skip_aux t acc = 
+        if t = pop then 
+          acc
+        else
+          who_skip_aux ((t + 1) mod n) (t :: acc)
+      in
+      who_skip_aux turn []
+
+    let pkt_to_int pkt =
+      match Packet.find_flow pkt with
       | A -> 0
       | B -> 1
-      | C -> 2
-      | n -> failwith Printf.(sprintf "Don't know how to route flow %s." (Flow.to_string n))
-    in
-    (* The ranks are as calculated above. *)
-    ([ (int_for_root, rank_for_root); (0, Rank.create 0.0 time) ], s', Time.epoch)
+      | C -> 2 
+      | D -> 3 
+      | E -> 4 
+      | F -> 5 
+      | G -> 6
 
-  let topology = Topo.one_level_ternary
+    let z_in s pkt = 
+      let time = Packet.time pkt in
+      let int_for_root = pkt_to_int pkt in
+      let r_i = "r_" ^ (string_of_int int_for_root) in
+      let rank_for_root = State.lookup r_i s in
+      let s' = State.rebind r_i (rank_for_root +. (float_of_int n)) s in
+      let rank_for_root = Rank.create rank_for_root time in
+      ([ (int_for_root, rank_for_root); (0, Rank.create 0.0 time) ], s', Time.epoch)
 
-  let control : Control.t =
-    {
-      s = State.create 3;
-      q = Pieotree.create topology;
-      z = scheduling_transaction;
-    }
+    let z_out s pkt = 
+      let turn = State.lookup "turn" s in
+      let turn' = ((int_of_float turn) + 1) mod n |> float_of_int in
+      let s' = State.rebind "turn" turn' s in
+      let skipped = who_skip (pkt_to_int pkt) (int_of_float turn) in
+      let f s i = 
+        let r_i = "r_" ^ (string_of_int i) in
+        State.rebind r_i (State.lookup r_i s +. (2.0 *. (float_of_int n))) s
+      in
+      List.fold_left f s' skipped
 
-  let simulate sim_length pkts =
-    Control.simulate sim_length 0.001 poprate pkts control
-end
+    let init_state = 
+      let zero_to_n = List.init n Fun.id in
+      let s = State.create (n + 1) |> State.rebind "turn" 0.0 in
+      let f s x = State.rebind ("r_" ^ (string_of_int x)) (float_of_int x) s in
+      List.fold_left f s zero_to_n
+
+    let topology = Topo.one_level_n_ary n
+
+    let control : Control.t =
+      {
+        s = init_state;
+        q = Pieotree.create topology;
+        z_in = z_in;
+        z_out = z_out;
+      }
+
+    let simulate sim_length pkts = 
+      Control.simulate sim_length 0.001 poprate pkts control
+  end : Alg_t
+)
+
+module RRobin_Ternary = (val rrobin 3)
 
 let wfq_helper s weight var_last_finish pkt_len time : Rank.t * State.t =
   (* The WFQ-style algorithms have a common pattern,
@@ -150,7 +180,12 @@ module WFQ_Ternary : Alg_t = struct
     |> State.rebind "C_weight" 0.3
 
   let control : Control.t =
-    { s = init_state; q = Pieotree.create topology; z = scheduling_transaction }
+    { 
+      s = init_state; 
+      q = Pieotree.create topology; 
+      z_in = scheduling_transaction; 
+      z_out = fun x -> fun _ -> x;
+    }
 
   let simulate sim_length pkts =
     Control.simulate sim_length 0.001 poprate pkts control
@@ -221,7 +256,8 @@ module HPFQ_Binary : Alg_t = struct
         |> State.rebind "B_weight" 0.25
         |> State.rebind "C_weight" 0.2;
       q = Pieotree.create topology;
-      z = scheduling_transaction;
+      z_in = scheduling_transaction;
+      z_out = fun x -> fun _ -> x;
     }
 
   let simulate sim_length pkts =
@@ -287,7 +323,8 @@ module TwoPol_Ternary : Alg_t = struct
         |> State.rebind "B_weight" 0.1
         |> State.rebind "CDE_weight" 0.8;
       q = Pieotree.create topology;
-      z = scheduling_transaction;
+      z_in = scheduling_transaction;
+      z_out = fun x -> fun _ -> x;
     }
 
   let simulate sim_length pkts =
@@ -414,7 +451,8 @@ module ThreePol_Ternary : Alg_t = struct
         |> State.rebind "F_weight" 0.4
         |> State.rebind "G_weight" 0.5;
       q = Pieotree.create topology;
-      z = scheduling_transaction;
+      z_in = scheduling_transaction;
+      z_out = fun x -> fun _ -> x;
     }
 
   let simulate sim_length pkts =
@@ -450,12 +488,17 @@ module Alg2B (Alg : Alg_t) : Alg_t = struct
   let topology, f = Topo.build_binary Alg.topology
   let f_tilde = Topo.lift_tilde f Alg.topology
 
-  let z' s pkt =
-    let pt, s', ts = Alg.control.z s pkt in
+  let z_in' s pkt =
+    let pt, s', ts = Alg.control.z_in s pkt in
     (f_tilde pt, s', ts)
 
   let control : Control.t =
-    { s = Alg.control.s; q = Pieotree.create topology; z = z' }
+    { 
+      s = Alg.control.s; 
+      q = Pieotree.create topology; 
+      z_in = z_in'; 
+      z_out = Alg.control.z_out;
+    }
 
   let simulate sim_length pkts =
     Control.simulate sim_length 0.001 poprate pkts control
@@ -492,7 +535,8 @@ module Extension_Flat : Alg_t = struct
     {
       s = State.create 1;
       q = Pieotree.create topology;
-      z = scheduling_transaction;
+      z_in = scheduling_transaction;
+      z_out = fun x -> fun _ -> x;
     }
 
   let simulate sim_length pkts =
@@ -511,12 +555,17 @@ module Alg2T (Alg : Alg_t) : Alg_t = struct
   *)
   let f_tilde = Topo.lift_tilde f Alg.topology
 
-  let z' s pkt =
-    let pt, s', ts = Alg.control.z s pkt in
+  let z_in' s pkt =
+    let pt, s', ts = Alg.control.z_in s pkt in
     (f_tilde pt, s', ts)
 
   let control : Control.t =
-    { s = Alg.control.s; q = Pieotree.create topology; z = z' }
+    { 
+      s = Alg.control.s; 
+      q = Pieotree.create topology; 
+      z_in = z_in';
+      z_out = Alg.control.z_out;
+    }
 
   let simulate sim_length pkts =
     Control.simulate sim_length 0.001 poprate pkts control
@@ -545,7 +594,8 @@ module Shifted_FCFS_Ternary : Alg_t = struct
     {
       s = State.create 1;
       q = Pieotree.create topology;
-      z = scheduling_transaction;
+      z_in = scheduling_transaction;
+      z_out = fun x -> fun _ -> x;
     }
 
   let simulate sim_length pkts =
@@ -594,7 +644,12 @@ module Rate_Limit_WFQ_Quaternary : Alg_t = struct
     |> State.rebind "C_throttle" 78.0
 
   let control : Control.t =
-    { s = init_state; q = Pieotree.create topology; z = scheduling_transaction }
+    { 
+      s = init_state; 
+      q = Pieotree.create topology; 
+      z_in = scheduling_transaction;
+      z_out = fun x -> fun _ -> x;
+    }
 
   let simulate sim_length pkts =
     Control.simulate sim_length 0.001 poprate pkts control

--- a/lib/control.mli
+++ b/lib/control.mli
@@ -1,4 +1,9 @@
-type sched_t = State.t -> Packet.t -> Path.t * State.t * Time.t
-type t = { s : State.t; q : Pieotree.t; z : sched_t }
+type t = 
+  { 
+    s : State.t; 
+    q : Pieotree.t; 
+    z_in : State.t -> Packet.t -> Path.t * State.t * Time.t;
+    z_out : State.t -> Packet.t -> State.t
+  }
 
 val simulate : float -> float -> float -> Packet.t list -> t -> Packet.t list

--- a/lib/packet.ml
+++ b/lib/packet.ml
@@ -154,19 +154,23 @@ let write_to_csv ts overdue filename =
   let ecsv = Csv.input_all (Csv.of_string payload) in
   Csv.save filename ecsv
 
+let mac_addr_to_flow s : Flow.t = match s with
+  | "10:10:10:10:10:10" -> A
+  | "20:20:20:20:20:20" -> B
+  | "30:30:30:30:30:30" -> C
+  | "40:40:40:40:40:40" -> D
+  | "50:50:50:50:50:50" -> E
+  | "60:60:60:60:60:60" -> F
+  | "70:70:70:70:70:70" -> G
+  | n -> failwith Printf.(sprintf "Unknown MAC address: %s." n)
+
 let find_flow t =
-  (* In pcap_gen.py, we create packets with sources based on their MAC addresses.
-     After going through our parser, those packets' sources get converted into
-     inscrutable integers.
-     This little function converts those integers back into human-readable strings.
-  *)
-  let open Flow in
-  match src t with
-  | 17661175009296 -> A (* Used to be address 10:10:10:10:10:10. *)
-  | 35322350018592 -> B (* 20...*)
-  | 52983525027888 -> C (* 30...*)
-  | 70644700037184 -> D (* 40...*)
-  | 88305875046480 -> E (* 50...*)
-  | 105967050055776 -> F (* 60...*)
-  | 123628225065072 -> G (* 70...*)
-  | n -> failwith Printf.(sprintf "Unknown source address: %d." n)
+  let hex = Printf.sprintf "%x" (src t) in
+  let n = String.length hex in
+  let buf = Buffer.create (3 * (n / 2) - 1) in
+  let f i c =
+    Buffer.add_char buf c;
+    if i mod 2 = 1 && i < n - 1 then Buffer.add_char buf ':' else ()
+  in
+  String.iteri f hex; 
+  Buffer.contents buf |> mac_addr_to_flow

--- a/lib/packet.ml
+++ b/lib/packet.ml
@@ -165,6 +165,17 @@ let mac_addr_to_flow s : Flow.t = match s with
   | n -> failwith Printf.(sprintf "Unknown MAC address: %s." n)
 
 let find_flow t =
+  (* In pcap_gen.py, we create packets with sources based on their MAC addresses.
+     After going through our parser, those sources get converted into decimals, as follows:
+     - start with MAC address `s`
+     - remove the `:`s from `s`, giving a hexadecimal number
+     - convert this number to decimal
+     This function converts those integers back into human-readable strings:
+     - convert to decimal to hex
+     - insert `:`s after every two digits
+     Then, it looks up the associated `flow` with `mac_addr_to_flow`.
+
+  *)
   let hex = Printf.sprintf "%x" (src t) in
   let n = String.length hex in
   let buf = Buffer.create (3 * (n / 2) - 1) in

--- a/lib/topo.ml
+++ b/lib/topo.ml
@@ -246,6 +246,8 @@ let rec lift_tilde (f : map_t) tree (path : Path.t) =
 let one_level_quaternary = Node [Star; Star; Star; Star]
 let one_level_ternary = Node [ Star; Star; Star ]
 let one_level_binary = Node [ Star; Star ]
+let one_level_n_ary n = Node (List.init n (fun _ -> Star))
+
 let two_level_binary = Node [ Node [ Star; Star ]; Star ]
 let two_level_ternary = Node [ Star; Star; Node [ Star; Star; Star ] ]
 

--- a/lib/topo.mli
+++ b/lib/topo.mli
@@ -12,6 +12,8 @@ val lift_tilde : map_t -> t -> Path.t -> Path.t
 val one_level_quaternary : t
 val one_level_ternary : t
 val one_level_binary : t
+val one_level_n_ary : int -> t
+
 val two_level_binary : t
 val two_level_ternary : t
 val three_level_ternary : t

--- a/test/simulate_binary.ml
+++ b/test/simulate_binary.ml
@@ -6,7 +6,7 @@ let simulate_binary () =
   run FCFS_Ternary_Bin.simulate fcfs_flow "fcfs_bin";
   run Shifted_FCFS_Ternary_Bin.simulate fcfs_flow "shifted_fcfs_bin";
   run Strict_Ternary_Bin.simulate strict_flow "strict_bin";
-  run RRobin_Ternary_Bin.simulate rr_flow "rr_bin";
+  run RRobin_Ternary_Bin.simulate two_then_three "rr_bin";
   run WFQ_Ternary_Bin.simulate wfq_flow "wfq_bin";
   run TwoPol_Ternary_Bin.simulate five_flows "twopol_bin";
   run ThreePol_Ternary_Bin.simulate seven_flows "threepol_bin";

--- a/test/simulate_handwritten.ml
+++ b/test/simulate_handwritten.ml
@@ -6,7 +6,7 @@ let simulate_handwritten () =
   run FCFS_Ternary.simulate fcfs_flow "fcfs";
   run Shifted_FCFS_Ternary.simulate fcfs_flow "shifted_fcfs";
   run Strict_Ternary.simulate strict_flow "strict";
-  run RRobin_Ternary.simulate rr_flow "rr";
+  run RRobin_Ternary.simulate two_then_three "rr";
   run WFQ_Ternary.simulate wfq_flow "wfq";
   run HPFQ_Binary.simulate two_then_three "hpfq";
   run TwoPol_Ternary.simulate five_flows "twopol";


### PR DESCRIPTION
Closes [#48 in packet-scheduling](https://github.com/cucapra/packet-scheduling/issues/48) by making the following changes 

- add `rrobin : int -> (module Alg_t)` to generate `n`-flow, round-robin policies on a one-level `n`-ary tree as per [#48](https://github.com/cucapra/packet-scheduling/issues/48)
- re-implement `RRobin_Ternary` as `rrobin 3`
- alter type `control` to allow mutating state at dequeue